### PR TITLE
Fix parameter name in function save_counters

### DIFF
--- a/utils/useful_functions.py
+++ b/utils/useful_functions.py
@@ -101,7 +101,7 @@ def execute_function(function_name, S, y):
     }[function_name]()
 
 
-def save_counters(c0, c1, elapsed_time, type, f):
+def save_counters(c0, c1, elapsed_time, shuffle_type, f):
     """Saves counters values obtained in the statistical analysis
 
     Parameters
@@ -112,7 +112,7 @@ def save_counters(c0, c1, elapsed_time, type, f):
         counter C1
     elapsed_time : float
         time to execute a test
-    type : str
+    shuffle_type : str
         type of shuffle selected
     f : str
         path to csv file


### PR DESCRIPTION
Name of the fourth parameter of function save_counters in utils/useful_functions.py changed from "type" to "shuffle_type" in order to match the variable used inside the function and to avoid the use of a reserved word in python.

Fixes #60.