### PR TITLE
Implement tests as NamedTuples

### DIFF
--- a/conf.toml
+++ b/conf.toml
@@ -5,7 +5,7 @@ input_file = "getbits_20230401_195315_RAW_BITS.BIN"
 bool_test_NIST = true
 bool_statistical_analysis = false
 # Select which tests to test IID assumption
-test_list_indexes = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '10']
+test_list_indexes = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 # step in reading bin file
 # calculated as n_symbols/2
 # step = 500
@@ -31,24 +31,11 @@ n_sequences_stat = 200
 n_symbols_stat = 1000
 n_iterations_c_stat = 500
 # Select which test index for counter distribution
-distribution_test_index = '6'
+distribution_test_index = 6
 # if True: FY shuffle,
 # if False: use random sampling from file
 bool_shuffle_stat = true
 # User sets preferred value
 p_value_stat = 2
 # Select which test indexes for shuffle/random comparison
-ref_numbers = ['1', '3', '4']
-
-[test_list]
-0 = "excursion_test"
-1 = "n_directional_runs"
-2 = "l_directional_runs"
-3 = "n_median_runs"
-4 = "l_median_runs"
-5 = "n_increases_decreases"
-6 = "avg_collision"
-7 = "max_collision"
-8 = "periodicity"
-9 = "covariance"
-10 = "compression"
+ref_numbers = [1, 3, 4]

--- a/permutation_tests.py
+++ b/permutation_tests.py
@@ -1,6 +1,7 @@
 import bz2
 import random
 import statistics
+import typing
 
 import utils.config
 
@@ -81,7 +82,7 @@ def s_prime_median(S):
     return S_prime
 
 
-def excursion_test(S):
+def _excursion(S):
     """Measures how far the running sum of sample values deviates from its
     average value at each point in the sequence
 
@@ -101,7 +102,7 @@ def excursion_test(S):
     return max(D)
 
 
-def n_directional_runs(S):
+def _n_directional_runs(S):
     """Measures the number of runs constructed using the relations between consecutive samples
 
     Parameters
@@ -123,7 +124,7 @@ def n_directional_runs(S):
     return T
 
 
-def l_directional_runs(S):
+def _l_directional_runs(S):
     """Measures the length of the longest run constructed using the relations between
     consecutive samples
 
@@ -156,7 +157,7 @@ def l_directional_runs(S):
     return T
 
 
-def n_increases_decreases(S):
+def _n_increases_decreases(S):
     """Measures the maximum number of increases or decreases between consecutive sample values
 
     Parameters
@@ -182,7 +183,7 @@ def n_increases_decreases(S):
     return max(count_minus, count_plus)
 
 
-def n_median_runs(S):
+def _n_median_runs(S):
     """Measures the number of runs that are constructed with respect to the median of the sequence
 
     Parameters
@@ -204,7 +205,7 @@ def n_median_runs(S):
     return T
 
 
-def l_median_runs(S):
+def _l_median_runs(S):
     """Measures the length of the longest run constructed with respect to the median of the sequence
 
     Parameters
@@ -236,7 +237,7 @@ def l_median_runs(S):
     return T
 
 
-def avg_c(S):
+def _avg_collision(S):
     """Counts the number of successive sample values until a duplicate is found
 
     Parameters
@@ -262,7 +263,7 @@ def avg_c(S):
     return statistics.mean(C) + 1
 
 
-def max_c(S):
+def _max_collision(S):
     """Counts the number of successive sample values until a duplicate is found
 
     Parameters
@@ -288,7 +289,7 @@ def max_c(S):
     return max(C) + 1
 
 
-def periodicity(S, y):
+def _periodicity(S, y):
     """Determines the number of periodic samples in the sequence
 
     Parameters
@@ -310,7 +311,7 @@ def periodicity(S, y):
     return T
 
 
-def covariance(S, p):
+def _covariance(S, p):
     """Measures the strength of the lagged correlation
 
     Parameters
@@ -331,7 +332,7 @@ def covariance(S, p):
     return T
 
 
-def compression(S):
+def _compression(S):
     """Removes redundancy in the sequence, involving commonly recurring subsequences of characters.
     Encodes input data as a character string containing a list of values separated by a single
     space. Compresses the character string with the bzip2 compression algorithm
@@ -351,45 +352,50 @@ def compression(S):
     return len(t)
 
 
-def execute_function(function_name, S, y):
-    """Calls functions to execute based on the function name provided
+_Test = typing.NamedTuple("Test", [("id", int), ("name", str), ("pretty_name", str), ("run", typing.Callable)])
+
+excursion = _Test(0, "excursion", "5.1.1 Excursion Test Statistic", _excursion)
+n_directional_runs = _Test(1, "n_directional_runs", "5.1.2 Number of Directional Runs", _n_directional_runs)
+l_directional_runs = _Test(2, "l_directional_runs", "5.1.3 Length of Directional Runs", _l_directional_runs)
+n_increases_decreases = _Test(
+    3, "n_increases_decreases", "5.1.4 Number of Increases and Decreases", _n_increases_decreases
+)
+n_median_runs = _Test(4, "n_median_runs", "5.1.5 Number of Runs Based on the Median", _n_median_runs)
+l_median_runs = _Test(5, "l_median_runs", "5.1.6 Length of Runs Based on Median", _l_median_runs)
+avg_collision = _Test(6, "avg_collision", "5.1.7 Average Collision Test Statistic", _avg_collision)
+max_collision = _Test(7, "max_collision", "5.1.8 Maximum Collision Test Statistic", _max_collision)
+periodicity = _Test(8, "periodicity", "5.1.9 Periodicity Test Statistic", _periodicity)
+covariance = _Test(9, "covariance", "5.1.10 Covariance Test Statistic", _covariance)
+compression = _Test(10, "compression", "5.1.11 Compression Test Statistic", _compression)
+tests = [
+    excursion,
+    n_directional_runs,
+    l_directional_runs,
+    n_increases_decreases,
+    n_median_runs,
+    l_median_runs,
+    avg_collision,
+    max_collision,
+    periodicity,
+    covariance,
+    compression,
+]
+
+
+def run_tests(S, p, test_list=[i.id for i in tests]):
+    """Run tests on a specified sequence, using a specified p value.
+    If no tests are specified, all tests are run.
 
     Parameters
     ----------
-    function_name : str
-        function name to be executed
     S : list of int
         sequence of sample values
-    y : int
-        lag parameter p
 
-    Returns
-    -------
-    int or float
-        output of the executed test function
-    """
-    return {
-        "excursion_test": lambda: excursion_test(S),
-        "n_directional_runs": lambda: n_directional_runs(S),
-        "l_directional_runs": lambda: l_directional_runs(S),
-        "n_median_runs": lambda: n_median_runs(S),
-        "l_median_runs": lambda: l_median_runs(S),
-        "n_increases_decreases": lambda: n_increases_decreases(S),
-        "avg_collision": lambda: avg_c(S),
-        "max_collision": lambda: max_c(S),
-        "periodicity": lambda: periodicity(S, y),
-        "covariance": lambda: covariance(S, y),
-        "compression": lambda: compression(S),
-    }[function_name]()
+    p : list of int
+        list of p values
 
-
-def execute_test_suite(sequence):
-    """Executes NIST test suite on a given sequence
-
-    Parameters
-    ----------
-    sequence : list of int
-        sequence of sample values
+    test_list : list of int
+        list of test indexes to run
 
     Returns
     -------
@@ -397,18 +403,12 @@ def execute_test_suite(sequence):
         list of tests results
     """
     T = []
-    for test_index in utils.config.config_data['global']['test_list_indexes']:
-        if test_index in ['8', '9'] and utils.config.config_data['nist_test']['bool_pvalue']:
-            # If bool_pvalue is True, p_values is expected to be a list. Iterate over it.
-            for p_value in utils.config.p:
-                result = execute_function(
-                    utils.config.config_data['test_list'][test_index], sequence, p_value
-                )
+    for test_index in test_list:
+        if test_index in [8, 9]:
+            for p_value in p:
+                result = tests[test_index].run(S, p_value)
                 T.append(result)
         else:
-            # For other cases or if bool_pvalue is False, execute the function with p_values directly.
-            result = execute_function(
-                utils.config.config_data['test_list'][test_index], sequence, utils.config.p
-            )
+            result = tests[test_index].run(S)
             T.append(result)
     return T

--- a/statistical_analysis/comparison_counters_FyR.py
+++ b/statistical_analysis/comparison_counters_FyR.py
@@ -5,6 +5,7 @@ import sys
 
 import pandas as pd
 
+import permutation_tests
 import utils.config
 import utils.plot
 import utils.useful_functions
@@ -22,77 +23,75 @@ def get_data(ref_numbers, Tj_norm):
 
     Returns
     -------
-    list of lists of int, list of lists of int and list of str
-        counters values and list of test names
+    list of lists of int, list of lists of int
+        counters values
     """
     # Construct the filenames based on reference numbers
     C0_fy = []
     C0_random = []
     for ref in ref_numbers:
-        if ref in utils.config.config_data["test_list"]:
-            if Tj_norm:
-                fy = os.path.abspath(
-                    os.path.join(
-                        "results",
-                        "counters_distribution",
-                        "FYShuffleTjNorm",
-                        f"fyShuffleTjNorm_{str(utils.config.config_data['test_list'][ref]).strip()}.csv",
-                    )
+        if Tj_norm:
+            fy = os.path.abspath(
+                os.path.join(
+                    "results",
+                    "counters_distribution",
+                    "FYShuffleTjNorm",
+                    f"fyShuffleTjNorm_{permutation_tests.tests[ref].name}.csv",
                 )
-                rand = os.path.abspath(
-                    os.path.join(
-                        "results",
-                        "counters_distribution",
-                        "RandomTjNorm",
-                        f"randomTjNorm_{str(utils.config.config_data['test_list'][ref]).strip()}.csv",
-                    )
+            )
+            rand = os.path.abspath(
+                os.path.join(
+                    "results",
+                    "counters_distribution",
+                    "RandomTjNorm",
+                    f"randomTjNorm_{permutation_tests.tests[ref].name}.csv",
                 )
-            else:
-                fy = os.path.abspath(
-                    os.path.join(
-                        "results",
-                        "counters_distribution",
-                        "FYShuffleTx",
-                        f"fyShuffleTx_{str(utils.config.config_data['test_list'][ref]).strip()}.csv",
-                    )
+            )
+        else:
+            fy = os.path.abspath(
+                os.path.join(
+                    "results",
+                    "counters_distribution",
+                    "FYShuffleTx",
+                    f"fyShuffleTx_{permutation_tests.tests[ref].name}.csv",
                 )
-                rand = os.path.abspath(
-                    os.path.join(
-                        "results",
-                        "counters_distribution",
-                        "RandomTx",
-                        f"randomTx_{str(utils.config.config_data['test_list'][ref]).strip()}.csv",
-                    )
+            )
+            rand = os.path.abspath(
+                os.path.join(
+                    "results",
+                    "counters_distribution",
+                    "RandomTx",
+                    f"randomTx_{permutation_tests.tests[ref].name}.csv",
                 )
-            if not os.path.exists(fy) or not os.path.exists(rand):
-                logging.error("File(s) for reference number %s do not exist.", ref)
-                sys.exit(1)
+            )
+        if not os.path.exists(fy) or not os.path.exists(rand):
+            logging.error("File(s) for reference number %s do not exist.", ref)
+            sys.exit(1)
 
-            try:
-                data1 = pd.read_csv(fy)
-                data2 = pd.read_csv(rand)
-                sixth_feature1 = data1.iloc[:, 5]
-                sixth_feature2 = data2.iloc[:, 5]
-                last_entry1 = sixth_feature1.iloc[-1]
-                last_entry2 = sixth_feature2.iloc[-1]
-                C0_fy.append(eval(last_entry1))
-                C0_random.append(eval(last_entry2))
-            except Exception as e:
-                logging.error(
-                    "Reading or processing files for %s: %s not successful",
-                    utils.config.config_data["test_list"][ref],
-                    e,
-                )
-                sys.exit(1)
-    return C0_fy, C0_random, [utils.config.config_data["test_list"][i] for i in ref_numbers]
+        try:
+            data1 = pd.read_csv(fy)
+            data2 = pd.read_csv(rand)
+            sixth_feature1 = data1.iloc[:, 5]
+            sixth_feature2 = data2.iloc[:, 5]
+            last_entry1 = sixth_feature1.iloc[-1]
+            last_entry2 = sixth_feature2.iloc[-1]
+            C0_fy.append(eval(last_entry1))
+            C0_random.append(eval(last_entry2))
+        except Exception as e:
+            logging.error("Reading or processing files for %s: %s not successful", permutation_tests.tests[ref], e)
+            sys.exit(1)
+    return C0_fy, C0_random
 
 
 def comparison_scatterplot():
     """Plots the comparison scatterplot between FY_shuffle counters and reading from file.
     The counters values are read from csv files.
     """
-    Cfy, Crand, l1 = get_data(utils.config.config_data["statistical_analysis"]["ref_numbers"], False)
-    Cfy_tjNorm, Crand_TjNorm, l2 = get_data(utils.config.config_data["statistical_analysis"]["ref_numbers"], True)
+    test_indexes = utils.config.config_data['statistical_analysis']['ref_numbers']
+    test_names = [permutation_tests.tests[i].name for i in test_indexes]
+
+    Cfy, Crand = get_data(test_indexes, False)
+    Cfy_tjNorm, Crand_TjNorm = get_data(test_indexes, True)
 
     # Define directory where to save the plot
     comparison_dir = "results/plots/comparison_RvsFY"
@@ -114,5 +113,5 @@ def comparison_scatterplot():
     os.makedirs(dir_comparison_TjNorm_run, exist_ok=True)
 
     # Plot the results
-    utils.plot.scatterplot_RvsFY(l1, Crand, Cfy, dir_comparison_run)
-    utils.plot.scatterplot_RvsFY_TjNorm(l2, Crand_TjNorm, Cfy_tjNorm, dir_comparison_TjNorm_run)
+    utils.plot.scatterplot_RvsFY(test_names, Crand, Cfy, dir_comparison_run)
+    utils.plot.scatterplot_RvsFY_TjNorm(test_names, Crand_TjNorm, Cfy_tjNorm, dir_comparison_TjNorm_run)

--- a/statistical_analysis/counters_FYShuffle_TjNorm.py
+++ b/statistical_analysis/counters_FYShuffle_TjNorm.py
@@ -11,7 +11,7 @@ import utils.plot
 import utils.useful_functions
 
 
-def counters_FY_TjNorm(S):
+def counters_FY_TjNorm(S, test):
     """Compute the counters C0 and C1 for a given test on a series of sequences obtained via FY-shuffle from a starting one.
     C0 is incremented if the result of the test T on a sequence is bigger than that on the following sequence; if the results of the
     test are equal the second sequence is ignored. Each pair of sequences is considered as disjointed from the following one.
@@ -34,51 +34,17 @@ def counters_FY_TjNorm(S):
         seq = permutation_tests.FY_shuffle(S.copy())
         C0 = 0
         C1 = 0
-        if (
-            utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "8"
-            or utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "9"
-        ):
-            Ti.append(
-                permutation_tests.execute_function(
-                    utils.config.config_data["test_list"][
-                        utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-                    ],
-                    seq,
-                    utils.config.config_data["statistical_analysis"]["p_value_stat"],
-                )
-            )
+        if test in [8, 9]:
+            Ti.append(permutation_tests.tests[test].run(seq, utils.config.config_data['statistical_analysis']['p_value_stat']))
         else:
-            Ti.append(
-                permutation_tests.execute_function(
-                    utils.config.config_data["test_list"][
-                        utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-                    ],
-                    seq,
-                    None,
-                )
-            )
+            Ti.append(permutation_tests.tests[test].run(seq))
         j = 1
         while j < utils.config.config_data["statistical_analysis"]["n_sequences_stat"]:
             seq = permutation_tests.FY_shuffle(S.copy())
-            if (
-                utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "8"
-                or utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "9"
-            ):
-                t = permutation_tests.execute_function(
-                    utils.config.config_data["test_list"][
-                        utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-                    ],
-                    seq,
-                    utils.config.config_data["statistical_analysis"]["p_value_stat"],
-                )
+            if test in [8, 9]:
+                t = permutation_tests.tests[test].run(seq, utils.config.config_data['statistical_analysis']['p_value_stat'])
             else:
-                t = permutation_tests.execute_function(
-                    utils.config.config_data["test_list"][
-                        utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-                    ],
-                    seq,
-                    None,
-                )
+                t = permutation_tests.tests[test].run(seq)
             if t == Ti[j - 1]:
                 continue
             else:
@@ -110,16 +76,17 @@ def FY_TjNorm(S):
         sequence of sample values
     """
     logging.debug("\nStatistical analysis FISHER YATES SHUFFLE WITH NORMALIZED Tj")
+    distribution_test_index = utils.config.config_data['statistical_analysis']['distribution_test_index']
     f = os.path.abspath(
         os.path.join(
             "results",
             "counters_distribution",
             "FYShuffleTjNorm",
-            f"fyShuffleTjNorm_{utils.config.config_data['test_list'][utils.config.config_data['statistical_analysis']['distribution_test_index']]}.csv",
+            f"fyShuffleTjNorm_{permutation_tests.tests[distribution_test_index].name}.csv",
         )
     )
     t = time.process_time()
-    C0, C1 = counters_FY_TjNorm(S)
+    C0, C1 = counters_FY_TjNorm(S, distribution_test_index)
     elapsed_time = time.process_time() - t
 
     # Saving results in test.csv

--- a/statistical_analysis/counters_FYShuffle_Tx.py
+++ b/statistical_analysis/counters_FYShuffle_Tx.py
@@ -11,7 +11,7 @@ import utils.plot
 import utils.useful_functions
 
 
-def counters_FYShuffle_Tx(S):
+def counters_FYShuffle_Tx(S, test):
     """Compute the counters C0 and C1 for a given test on a series of sequences obtained via FY-shuffle from a starting one.
     The given test is performed on the first sequence to obtain the reference value:
     C0 is incremented if the result of the test T computed on a sequence is bigger than that it, C1 is incremented if they are equal.
@@ -29,25 +29,10 @@ def counters_FYShuffle_Tx(S):
     counters_0 = []
     counters_1 = []
     # Calculate reference statistics
-    if (
-        utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "8"
-        or utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "9"
-    ):
-        Tx = permutation_tests.execute_function(
-            utils.config.config_data["test_list"][
-                utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-            ],
-            S,
-            utils.config.config_data["statistical_analysis"]["p_value_stat"],
-        )
+    if test in [8, 9]:
+        Tx = permutation_tests.tests[test].run(S, utils.config.config_data['statistical_analysis']['p_value_stat'])
     else:
-        Tx = permutation_tests.execute_function(
-            utils.config.config_data["test_list"][
-                utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-            ],
-            S,
-            None,
-        )
+        Tx = permutation_tests.tests[test].run(S)
 
     # S_shuffled will move by a P_pointer for every n_sequences
     for i in tqdm(range(utils.config.config_data["statistical_analysis"]["n_iterations_c_stat"])):
@@ -56,29 +41,12 @@ def counters_FYShuffle_Tx(S):
         Ti = []
         for k in range(utils.config.config_data["statistical_analysis"]["n_sequences_stat"]):
             s_shuffled = permutation_tests.FY_shuffle(S.copy())
-            if (
-                utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "8"
-                or utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "9"
-            ):
+            if test in [8, 9]:
                 Ti.append(
-                    permutation_tests.execute_function(
-                        utils.config.config_data["test_list"][
-                            utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-                        ],
-                        s_shuffled,
-                        utils.config.config_data["statistical_analysis"]["p_value_stat"],
-                    )
+                    permutation_tests.tests[test].run(s_shuffled, utils.config.config_data['statistical_analysis']['p_value_stat'])
                 )
             else:
-                Ti.append(
-                    permutation_tests.execute_function(
-                        utils.config.config_data["test_list"][
-                            utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-                        ],
-                        s_shuffled,
-                        None,
-                    )
-                )
+                Ti.append(permutation_tests.tests[test].run(s_shuffled))
 
         for z in range(len(Ti)):
             if Tx > Ti[z]:
@@ -104,16 +72,17 @@ def FY_Tx(S):
         sequence of sample values
     """
     logging.debug("Statistical analysis FISHER YATES SHUFFLE FOR Tx VALUES")
+    distribution_test_index = utils.config.config_data['statistical_analysis']['distribution_test_index']
     f = os.path.abspath(
         os.path.join(
             "results",
             "counters_distribution",
             "FYShuffleTx",
-            f"fyShuffleTx_{utils.config.config_data['test_list'][utils.config.config_data['statistical_analysis']['distribution_test_index']]}.csv",
+            f"fyShuffleTx_{permutation_tests.tests[distribution_test_index].name}.csv",
         )
     )
     t = time.process_time()
-    C0, C1 = counters_FYShuffle_Tx(S)
+    C0, C1 = counters_FYShuffle_Tx(S, distribution_test_index)
     elapsed_time = time.process_time() - t
 
     # Saving results in test.csv

--- a/statistical_analysis/counters_Random_TjNorm.py
+++ b/statistical_analysis/counters_Random_TjNorm.py
@@ -5,6 +5,7 @@ import time
 
 from tqdm import tqdm
 
+import permutation_tests
 import utils.config
 import utils.plot
 import utils.shuffles
@@ -38,9 +39,7 @@ def counters_random_TjNorm():
             index,
             utils.config.config_data["statistical_analysis"]["n_symbols_stat"],
             utils.config.config_data["statistical_analysis"]["n_sequences_stat"],
-            utils.config.config_data["test_list"][
-                utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-            ],
+            utils.config.config_data["statistical_analysis"]["distribution_test_index"],
         )
 
         for z in range(0, len(Ti) - 1, 2):
@@ -63,7 +62,7 @@ def counters_random_TjNorm():
     return counters_0, counters_1
 
 
-def Random_TjNorm(S):
+def Random_TjNorm(S, test):
     """Calculates counter 0 and counter 1 list of values considering a series of random sequences read from file,
     save the values in a file and plot the distribution
 
@@ -71,6 +70,8 @@ def Random_TjNorm(S):
     ----------
     S : list of int
         sequence of sample values
+    test : int
+        index of the test used to produce the counters
     """
     logging.debug("\nStatistical analysis RANDOM SAMPLING FROM FILE WITH Tj NORMALIZED")
     f = os.path.abspath(
@@ -78,7 +79,7 @@ def Random_TjNorm(S):
             "results",
             "counters_distribution",
             "RandomTjNorm",
-            f"randomTjNorm_{utils.config.config_data['test_list'][utils.config.config_data['statistical_analysis']['distribution_test_index']]}.csv",
+            f"randomTjNorm_{permutation_tests.tests[test].name}.csv",
         )
     )
     t = time.process_time()

--- a/statistical_analysis/counters_Random_Tx.py
+++ b/statistical_analysis/counters_Random_Tx.py
@@ -12,7 +12,7 @@ import utils.shuffles
 import utils.useful_functions
 
 
-def counters_Random_Tx(S):
+def counters_Random_Tx(S, test):
     """Compute the counters C0 and C1 for a given test on a series of random sequences read from file.
     The given test is performed on the first sequence to obtain the reference value: C0 is incremented if the result
     of the test T computed on a sequence is bigger than that it, C1 is incremented if they are equal.
@@ -28,25 +28,10 @@ def counters_Random_Tx(S):
         counter 0 and counter 1 lists of values
     """
 
-    if (
-        utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "8"
-        or utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "9"
-    ):
-        Tx = permutation_tests.execute_function(
-            utils.config.config_data["test_list"][
-                utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-            ],
-            S,
-            utils.config.config_data["statistical_analysis"]["p_value_stat"],
-        )
+    if test in [8, 9]:
+        Tx = permutation_tests.tests[test].run(S, utils.config.config_data['statistical_analysis']['p_value_stat'])
     else:
-        Tx = permutation_tests.execute_function(
-            utils.config.config_data["test_list"][
-                utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-            ],
-            S,
-            None,
-        )
+        Tx = permutation_tests.tests[test].run(S)
     counters_0 = []
     counters_1 = []
     index = utils.config.config_data["statistical_analysis"]["n_symbols_stat"] / 2
@@ -61,29 +46,10 @@ def counters_Random_Tx(S):
         )
         Ti = []
         for k in S_shuffled:
-            if (
-                utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "8"
-                or utils.config.config_data["statistical_analysis"]["distribution_test_index"] == "9"
-            ):
-                Ti.append(
-                    permutation_tests.execute_function(
-                        utils.config.config_data["test_list"][
-                            utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-                        ],
-                        k,
-                        utils.config.config_data["statistical_analysis"]["p_value_stat"],
-                    )
-                )
+            if test in [8, 9]:
+                Ti.append(permutation_tests.tests[test].run(k, utils.config.config_data['statistical_analysis']['p_value_stat']))
             else:
-                Ti.append(
-                    permutation_tests.execute_function(
-                        utils.config.config_data["test_list"][
-                            utils.config.config_data["statistical_analysis"]["distribution_test_index"]
-                        ],
-                        k,
-                        None,
-                    )
-                )
+                Ti.append(permutation_tests.tests[test].run(k))
 
         for z in range(len(Ti)):
             if Tx > Ti[z]:
@@ -113,16 +79,17 @@ def Random_Tx(S):
         sequence of sample values
     """
     logging.debug("\nStatistical analysis RANDOM SAMPLING FROM FILE FOR Tx VALUES")
+    distribution_test_index = utils.config.config_data['statistical_analysis']['distribution_test_index']
     f = os.path.abspath(
         os.path.join(
             "results",
             "counters_distribution",
             "RandomTx",
-            f"RandomTx_{utils.config.config_data['test_list'][utils.config.config_data['statistical_analysis']['distribution_test_index']]}.csv",
+            f"RandomTx_{permutation_tests.tests[distribution_test_index].name}.csv",
         )
     )
     t = time.process_time()
-    C0, C1 = counters_Random_Tx(S)
+    C0, C1 = counters_Random_Tx(S, distribution_test_index)
     elapsed_time = time.process_time() - t
 
     # Saving results in test.csv

--- a/utils/config.py
+++ b/utils/config.py
@@ -5,6 +5,8 @@ CONFIGURATION FILE - CHANGE VARIABLES TO RUN THE DESIRED CONFIGURATION
 import logging
 import tomllib
 
+import permutation_tests
+
 
 def parse_config_file(file_path: str) -> dict:
     """Parse the specified file into a Python dictionary
@@ -36,7 +38,7 @@ if config_data['nist_test']['bool_pvalue']:
     p = [1, 2, 8, 16, 32]
 else:
     # User sets preferred value
-    p = 2
+    p = [2]
 
 # step in reading bin file
 step = config_data['nist_test']['n_symbols'] / 2
@@ -69,7 +71,7 @@ def config_info():
     logging.debug("CONFIG INFO - NIST")
     logging.debug("Number of symbols per sequence = %s", config_data['nist_test']['n_symbols'])
     logging.debug("Number of shuffled sequences = %s", config_data['nist_test']['n_sequences'])
-    ts = [config_data['test_list'][i] for i in config_data['global']['test_list_indexes']]
+    ts = [permutation_tests.tests[i].name for i in config_data['global']['test_list_indexes']]
     logging.debug("Tests for entropy validation selected: %s", ts)
     if config_data['nist_test']['bool_first_seq']:
         logging.debug("Reference sequence read from the beginning of the file")
@@ -84,8 +86,8 @@ def config_info():
     logging.debug("Number of symbols per sequence = %s", config_data['statistical_analysis']['n_symbols_stat'])
     logging.debug("Number of shuffled sequences = %s", config_data['statistical_analysis']['n_sequences_stat'])
     logging.debug("Number of iterations for counter: %s", config_data['statistical_analysis']['n_iterations_c_stat'])
-    logging.debug("Test selected for counter distribution analysis: %s", config_data['test_list'][config_data['statistical_analysis']['distribution_test_index']])
-    comp = [config_data['test_list'][i] for i in config_data['statistical_analysis']['ref_numbers']]
+    logging.debug("Test selected for counter distribution analysis: %s", permutation_tests.tests[config_data['statistical_analysis']['distribution_test_index']].name)
+    comp = [permutation_tests.tests[i].name for i in config_data['statistical_analysis']['ref_numbers']]
     logging.debug("Tests selected test for shuffle/random comparison: %s", comp)
     logging.debug("p parameter used: user value: %s", config_data['statistical_analysis']['p_value_stat'])
     logging.debug("----------------------------------------------------------------\n \nMAIN")

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -4,6 +4,7 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 
+import permutation_tests
 import utils.config
 
 
@@ -268,10 +269,7 @@ def counters_distribution_Tx(c, n_seq, n_iter, t, plot_dir):
     ax.text(0.05, 0.95, textstr, transform=ax.transAxes, fontsize=10, verticalalignment="top", bbox=props)
 
     # Setting title and positioning the legend
-    ax.set_title(
-        f"Distribution {t} of the counter for test {utils.config.config_data['test_list'][utils.config.config_data['statistical_analysis']['distribution_test_index']]}",
-        size=14,
-    )
+    ax.set_title(f"Distribution {t} of the counter for test {permutation_tests.tests[utils.config.config_data['statistical_analysis']['distribution_test_index']].name}", size=14)
     plt.legend(loc="upper right")
 
     plot_filename = f"{t.replace(' ', '_')}_{utils.config.config_data['test_list'][utils.config.config_data['statistical_analysis']['distribution_test_index']].replace(' ', '_')}.pdf"
@@ -355,10 +353,7 @@ def counters_distribution_Tj(c, n_seq, n_iter, t, plot_dir):
     props = dict(boxstyle="round", facecolor="w", alpha=0.5)
     ax.text(0.05, 0.95, textstr, transform=ax.transAxes, fontsize=14, verticalalignment="top", bbox=props)
 
-    ax.set_title(
-        f"Distribution {t} of the counter for test {utils.config.config_data['test_list'][utils.config.config_data['statistical_analysis']['distribution_test_index']]}",
-        size=14,
-    )
+    ax.set_title(f"Distribution {t} of the counter for test {permutation_tests.tests[utils.config.config_data['statistical_analysis']['distribution_test_index']].name}", size=14)
     plt.legend()
 
     plot_filename = f"{t.replace(' ', '_')}_{utils.config.config_data['test_list'][utils.config.config_data['statistical_analysis']['distribution_test_index']].replace(' ', '_')}.pdf"

--- a/utils/shuffles.py
+++ b/utils/shuffles.py
@@ -48,7 +48,7 @@ def shuffle_from_file(ind, n_symb, n_seq):
         return sequences
 
 
-def shuffle_from_file_Norm(index, n_symb, n_seq, test):
+def shuffle_from_file_Norm(index, n_symb, n_seq, test: int):
     """Version of shuffle_from_file function for normalized Tj.
     The sequence it reads has the same result T on a given test as the previous
     sequence (T(j-1)), it discards it and passes to the next sequence. This is because for Tj normalized we want the
@@ -67,8 +67,8 @@ def shuffle_from_file_Norm(index, n_symb, n_seq, test):
         number of symbols
     n_seq : int
         number of sequences
-    test : str
-        function name to be executed
+    test : int
+        test index to be executed
 
     Returns
     -------
@@ -91,11 +91,11 @@ def shuffle_from_file_Norm(index, n_symb, n_seq, test):
             S.append(symbol2)
         index += utils.config.step
 
-        if utils.config.config_data['statistical_analysis']['distribution_test_index'] == '8' or utils.config.config_data['statistical_analysis']['distribution_test_index'] == '9':
-            t = permutation_tests.execute_function(test, S, utils.config.config_data['statistical_analysis']['p_value_stat'])
+        if test in [8, 9]:
+            t = permutation_tests.tests[test].run(S, utils.config.config_data['statistical_analysis']['p_value_stat'])
             Ti.append(t)
         else:
-            t = permutation_tests.execute_function(test, S, None)
+            t = permutation_tests.tests[test].run(S)
             Ti.append(t)
         sequences.append(S)
 
@@ -114,10 +114,10 @@ def shuffle_from_file_Norm(index, n_symb, n_seq, test):
 
             index += utils.config.step
 
-            if utils.config.config_data['statistical_analysis']['distribution_test_index'] == '8' or utils.config.config_data['statistical_analysis']['distribution_test_index'] == '9':
-                t = permutation_tests.execute_function(test, S, utils.config.config_data['statistical_analysis']['p_value_stat'])
+            if test in [8, 9]:
+                t = permutation_tests.tests[test].run(S, utils.config.config_data['statistical_analysis']['p_value_stat'])
             else:
-                t = permutation_tests.execute_function(test, S, None)
+                t = permutation_tests.tests[test].run(S)
 
             if t == Ti[z - 1]:
                 continue

--- a/utils/useful_functions.py
+++ b/utils/useful_functions.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import numpy as np
 import pandas as pd
 
+import permutation_tests
 import utils.config
 
 
@@ -41,7 +42,7 @@ def save_counters(c0, c1, elapsed_time, shuffle_type, f):
         utils.config.config_data['statistical_analysis']['n_symbols_stat'],
         utils.config.config_data['statistical_analysis']['n_sequences_stat'],
         shuffle_type,
-        utils.config.config_data['test_list'][utils.config.config_data['statistical_analysis']['distribution_test_index']],
+        permutation_tests.tests[utils.config.config_data['statistical_analysis']['distribution_test_index']].name,
         c0,
         c1,
         str(elapsed),
@@ -74,7 +75,7 @@ def save_failure_test(C0, C1, b, test_time):
         total process time
     """
     header = ["n_symbols", "n_sequences", "test_list", "COUNTER_0", "COUNTER_1", "IID", "process_time", "date"]
-    t = [utils.config.config_data['test_list'].get(i) for i in utils.config.config_data['global']['test_list_indexes']]
+    t = [permutation_tests.tests[i].name for i in utils.config.config_data['global']['test_list_indexes']]
     d = [utils.config.config_data['nist_test']['n_symbols'], utils.config.config_data['nist_test']['n_sequences'], t, C0, C1, b, test_time, str(datetime.now())]
     dt = pd.DataFrame(d, index=header).T
     h = True
@@ -118,17 +119,16 @@ def save_test_values(Tx, Ti):
             "compression",
         ]
     else:
-        header = [utils.config.config_data['test_list'][k] for k in utils.config.config_data['global']['test_list_indexes']]
+        header = [permutation_tests.tests[i].name for i in utils.config.config_data['global']['test_list_indexes']]
     df2 = pd.DataFrame(np.array(Ti), columns=header)
     a = pd.DataFrame([Tx], columns=header)
     df = pd.concat([a, df2]).reset_index(drop=True)
     # df.insert("time Ti", tf, True)
     file_path = "results/save_test_values.csv"
     write_header = not os.path.isfile(file_path)
-    write_mode = "w" if write_header else "a"
 
     # Save the DataFrame to CSV, without the index and with headers only if writing for the first time
-    df.to_csv(file_path, mode=write_mode, header=write_header, index=False)
+    df.to_csv(file_path, mode="a", header=write_header, index=False)
 
 
 def benchmark_timing(tot_time, p):


### PR DESCRIPTION
Implement tests as pseudo-objects using typed NamedTuples. This way each test can contain its id, name, printable name, and function.

Define a list of all implemented tests in permutation_tests.py, and use it as a reference instead of the test_list fake configuration parameter.