### PR TITLE
Drop benchmark timing

### DIFF
--- a/main_parallelized.py
+++ b/main_parallelized.py
@@ -173,10 +173,11 @@ def iid_test_function():
     logging.debug("C0 = %s", C0)
     logging.debug("C1 = %s", C1)
 
-    if iid_result(C0, C1, Tx):
-        logging.info("IID assumption validated")
-    else:
-        logging.info("IID assumption rejected")
+    IID_assumption = iid_result(C0, C1, Tx)
+
+    logging.info("IID assumption %s", "validated" if IID_assumption else "rejected")
+    # save results of the IID validation
+    utils.useful_functions.save_IID_validation(C0, C1, IID_assumption, ti)
 
     # plots
     if utils.config.config_data["nist_test"]["see_plots"]:

--- a/utils/useful_functions.py
+++ b/utils/useful_functions.py
@@ -60,7 +60,7 @@ def save_counters(c0, c1, elapsed_time, shuffle_type, f):
     df.to_csv(f, mode="a", header=h, index=False)
 
 
-def save_failure_test(C0, C1, b, test_time):
+def save_IID_validation(C0, C1, b, test_time):
     """Saves IID failure and the counters values generated in the NIST test part
 
     Parameters
@@ -88,11 +88,11 @@ def save_failure_test(C0, C1, b, test_time):
     ]
     dt = pd.DataFrame(d, index=header).T
     h = True
-    if os.path.exists("results/failure_rate.csv"):
+    if os.path.exists("results/IID_validation.csv"):
         h = False
-        dt.to_csv("results/failure_rate.csv", mode="a", header=h, index=False)
+        dt.to_csv("results/IID_validation.csv", mode="a", header=h, index=False)
     else:
-        dt.to_csv("results/failure_rate.csv", mode="a", header=h, index=False)
+        dt.to_csv("results/IID_validation.csv", mode="a", header=h, index=False)
 
 
 def save_test_values(Tx, Ti):


### PR DESCRIPTION
* remove redundant benchmark timing
* rename save_failure_tests to save_IID_validation and use it to save the information that was saved by benchmark_timing

Fixes #72.