### PR TITLE
Remove bool_pvalue configuration parameter from the code

### DIFF
--- a/main_parallelized.py
+++ b/main_parallelized.py
@@ -128,7 +128,7 @@ def iid_plots(Tx, Ti):
 
     Ti_transposed = np.transpose(Ti)
     for t in range(len(Tx)):
-        if utils.config.config_data["nist_test"]["bool_pvalue"]:
+        if utils.config.p == [1, 2, 8, 16, 32]:
             # Handle the special case for test 8 ('periodicity')
             if 8 <= t <= 12:
                 p_index = t - 8  # Adjust index to map to the correct p value
@@ -145,9 +145,11 @@ def iid_plots(Tx, Ti):
                 test_name = permutation_tests.tests[t].name
             utils.plot.histogram_TxTi(Tx[t], Ti_transposed[t], test_name, dir_hist_run)
             utils.plot.scatterplot_TxTi(Tx[t], Ti_transposed[t], test_name, dir_sc_run)
-        else:
+        elif len(utils.config.p) == 1:
             utils.plot.histogram_TxTi(Tx[t], Ti_transposed[t], permutation_tests.tests[t].name, dir_hist_run)
             utils.plot.scatterplot_TxTi(Tx[t], Ti_transposed[t], permutation_tests.tests[t].name, dir_sc_run)
+        else:
+            raise Exception("Support for arbitrary p values not implemented yet")
 
 
 def iid_test_function():

--- a/utils/config.py
+++ b/utils/config.py
@@ -88,10 +88,10 @@ def config_info():
         logging.debug("Reference sequence read from the beginning of the file")
     else:
         logging.debug("Reference sequence read from the end of the file")
-    if config_data["nist_test"]["bool_pvalue"]:
+    if p == [1, 2, 8, 16, 32]:
         logging.debug("p parameter used: NIST")
     else:
-        logging.debug("p parameter used: user value \n")
+        logging.debug("p parameter used: user value")
 
     logging.debug("\nCONFIG INFO - STATISTICAL ANALYSIS")
     logging.debug("Number of symbols per sequence = %s", config_data["statistical_analysis"]["n_symbols_stat"])

--- a/utils/useful_functions.py
+++ b/utils/useful_functions.py
@@ -105,7 +105,7 @@ def save_test_values(Tx, Ti):
     Ti : list of float
         Ti test values calculated on the shuffled sequences
     """
-    if utils.config.config_data["nist_test"]["bool_pvalue"]:
+    if utils.config.p == [1, 2, 8, 16, 32]:
         header = [
             "excursion_test",
             "n_directional_runs",
@@ -127,8 +127,11 @@ def save_test_values(Tx, Ti):
             "covariance_p4",
             "compression",
         ]
-    else:
+    elif len(utils.config.p) == 1:
         header = [permutation_tests.tests[i].name for i in utils.config.config_data["global"]["test_list_indexes"]]
+    else:
+        raise Exception("Support for arbitrary p values not implemented yet")
+
     df2 = pd.DataFrame(np.array(Ti), columns=header)
     a = pd.DataFrame([Tx], columns=header)
     df = pd.concat([a, df2]).reset_index(drop=True)


### PR DESCRIPTION
Remove all usages of `bool_pvalue` from the codebase, so that it can then be safely dropped when updating the configuration handling in #98.

As stated in the review of #98:
> The bool_pvalue parameter should not exist anymore. We should have one pvalues configuration parameter for the IID testing part, that defaults to the NIST values ([1, 2, 8, 16, 32]), and can be overridden by the user.

Note: the code only works with the NIST values, or with a single user-specified value. We can think about how to add support for arbitrary numbers of p values in the future. I have added a specific exception to catch this case.

Fixes #80