### PR TITLE
Fix docstring of shuffle_from_file

### DIFF
--- a/utils/shuffles.py
+++ b/utils/shuffles.py
@@ -9,6 +9,8 @@ def shuffle_from_file(file, ind, n_symb, n_seq):
 
     Parameters
     ----------
+    file : str
+        the input binary file
     ind : int
         position where to read in the file
     n_symb : int


### PR DESCRIPTION
Add the missing first parameter of the function into the docstring.

Fixes #140 .