### PR TITLE
Remove scatterplot

### DIFF
--- a/main_parallelized.py
+++ b/main_parallelized.py
@@ -113,7 +113,7 @@ def FY_test_mode_parallel(conf: utils.config.Config, S: list[int]):
 
 
 def iid_plots(conf: utils.config.Config, Tx, Ti):
-    """Plot histogram and scatterplot of Ti values with respect to the Tx test value
+    """Plot histogram of Ti values with respect to the Tx test value
 
     Parameters
     ----------
@@ -124,10 +124,8 @@ def iid_plots(conf: utils.config.Config, Tx, Ti):
     Ti : list of int
         test values calculated on shuffled sequences
     """
-    scatterplot_dir = os.path.join("IID_validation", "scatterplot_TxTi")
     histo_dir = os.path.join("IID_validation", "histogram_TxTi")
     # Ensure the directory exists
-    os.makedirs(scatterplot_dir, exist_ok=True)
     os.makedirs(histo_dir, exist_ok=True)
 
     Ti_transposed = np.transpose(Ti)
@@ -148,12 +146,8 @@ def iid_plots(conf: utils.config.Config, Tx, Ti):
                 # Direct mapping for other tests
                 test_name = permutation_tests.tests[t].name
             utils.plot.histogram_TxTi(Tx[t], Ti_transposed[t], test_name, histo_dir)
-            utils.plot.scatterplot_TxTi(conf, Tx[t], Ti_transposed[t], test_name, scatterplot_dir)
         elif len(conf.nist.p) == 1:
             utils.plot.histogram_TxTi(Tx[t], Ti_transposed[t], permutation_tests.tests[t].name, histo_dir)
-            utils.plot.scatterplot_TxTi(
-                conf, Tx[t], Ti_transposed[t], permutation_tests.tests[t].name, scatterplot_dir
-            )
         else:
             raise Exception("Support for arbitrary p values not implemented yet")
 

--- a/utils/plot.py
+++ b/utils/plot.py
@@ -54,51 +54,6 @@ def histogram_TxTi(Tx, Ti, t, plot_dir_h):
     plt.close()
 
 
-def scatterplot_TxTi(conf: utils.config.Config, Tx, Ti, t: str, plot_dir_s: str):
-    """Plots tests values in a scatter plot with one dot for each observation of every shuffled sequence
-    and a red line for the reference Tx value
-
-    Parameters
-    ----------
-    conf : utils.config.Config
-        application configuration parameters
-    Tx : list of float
-        Tx test values calculated on one sequence
-    Ti : list of float
-        Ti test values calculated on the shuffled sequences
-    t : str
-        test executed
-    plot_dir_s : str
-        directory where to save the plot
-    """
-    x = [k for k in range(conf.nist.n_permutations)]
-
-    fig, ax = plt.subplots(figsize=(11, 7))
-    ax.scatter(x, Ti, s=10)
-    plt.xticks(
-        np.arange(
-            0,
-            conf.nist.n_permutations,
-            conf.nist.n_permutations / 10,
-        )
-    )
-    plt.axhline(y=Tx, color="r", linestyle="-", label="axvline - full height")
-    ax.text(Tx, 0.5, f"Tx={Tx}")
-
-    my_text = f"n_simbols={conf.nist.n_symbols}\n" + f"n_iterations={conf.nist.n_permutations}\n" + f"Tx={Tx}"
-    props = dict(boxstyle="square", facecolor="grey", alpha=0.15)
-    ax.text(0.93, 1.13, my_text, transform=ax.transAxes, fontsize=12, verticalalignment="top", bbox=props)
-
-    plt.subplots_adjust(left=0.1)
-    plt.title(t)
-
-    plot_filename = f"{t.replace(' ', '_')}.pdf"
-    plot_path = os.path.join(plot_dir_s, plot_filename)
-
-    plt.savefig(plot_path)
-    plt.close()
-
-
 def scatterplot_RvsFY(test, C0r, C0fy, plot_dir):
     """Plots the graph that compares the distribution of counters C0 computed considering sequences read from file with
     the one obtained through FY shuffling.


### PR DESCRIPTION
Remove scatteplot in the IID_validation section, as the histogram portrays the same information and does so better.

Fixes #152.