### PR TITLE
Rename n_sequences to n_permutations

### DIFF
--- a/conf.toml
+++ b/conf.toml
@@ -18,7 +18,7 @@ p = [2]
 
 [statistical_analysis]
 selected_tests = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-n_sequences = 20
+n_permutations = 20
 n_symbols = 100
 n_iterations = 50
 # User sets preferred value

--- a/main_parallelized.py
+++ b/main_parallelized.py
@@ -161,19 +161,19 @@ def statistical_analysis_function(conf: utils.config.Config):
         # Calculate counters for Tx and TjNorm methods
         t0 = time.process_time()
         Ti = permutation_tests.run_tests_permutations(
-            S, conf.stat.n_sequences, conf.stat.selected_tests, [conf.stat.p], conf.parallel
+            S, conf.stat.n_permutations, conf.stat.selected_tests, [conf.stat.p], conf.parallel
         )
         t1 = time.process_time()
         C0_Tx, C1_Tx = permutation_tests.calculate_counters(Tx, Ti)
         t2 = time.process_time()
         C0_TjNorm, C1_TjNorm = statistical_analysis.calculate_counters_TjNorm(conf, S, Ti)
         t3 = time.process_time()
-        IID_assumption_Tx = permutation_tests.iid_result(C0_Tx, C1_Tx, conf.stat.n_sequences)
-        IID_assumption_TjNorm = permutation_tests.iid_result(C0_TjNorm, C1_TjNorm, int(conf.stat.n_sequences / 2))
+        IID_assumption_Tx = permutation_tests.iid_result(C0_Tx, C1_Tx, conf.stat.n_permutations)
+        IID_assumption_TjNorm = permutation_tests.iid_result(C0_TjNorm, C1_TjNorm, int(conf.stat.n_permutations / 2))
         # Save the values of the counters
         utils.useful_functions.save_counters(
             conf.stat.n_symbols,
-            conf.stat.n_sequences,
+            conf.stat.n_permutations,
             conf.stat.selected_tests,
             C0_Tx,
             C1_Tx,
@@ -183,7 +183,7 @@ def statistical_analysis_function(conf: utils.config.Config):
         )
         utils.useful_functions.save_counters(
             conf.stat.n_symbols,
-            conf.stat.n_sequences,
+            conf.stat.n_permutations,
             conf.stat.selected_tests,
             C0_TjNorm,
             C1_TjNorm,
@@ -200,11 +200,14 @@ def statistical_analysis_function(conf: utils.config.Config):
     # Plot the distributions of the counters
     for t in range(len(conf.stat.selected_tests)):
         utils.plot.counters_distribution_Tx(
-            [i[t] for i in counters_C0_Tx], conf.stat.n_sequences, conf.stat.n_iterations, conf.stat.selected_tests[t]
+            [i[t] for i in counters_C0_Tx],
+            conf.stat.n_permutations,
+            conf.stat.n_iterations,
+            conf.stat.selected_tests[t],
         )
         utils.plot.counters_distribution_Tj(
             [i[t] for i in counters_C0_TjNorm],
-            conf.stat.n_sequences,
+            conf.stat.n_permutations,
             conf.stat.n_iterations,
             conf.stat.selected_tests[t],
         )
@@ -307,9 +310,9 @@ def main():
         help="Indexes of the tests to execute. See README.md for the full list [Default: all].",
     )
     stat_args.add_argument(
-        "--stat_n_sequences",
+        "--stat_n_permutations",
         type=int,
-        help=f"Number of sequences [Default: {utils.config.Config.StatConfig.DEFAULT_N_SEQUENCES}].",
+        help=f"Number of sequences [Default: {utils.config.Config.StatConfig.DEFAULT_N_PERMUTATIONS}].",
     )
     stat_args.add_argument(
         "--stat_n_symbols",

--- a/permutation_tests.py
+++ b/permutation_tests.py
@@ -447,9 +447,9 @@ def calculate_counters(Tx: list[float], Ti: list[list[float]]) -> tuple[list[int
     return C0, C1
 
 
-def iid_result(C0: list[int], C1: list[int], n_sequences: int) -> bool:
+def iid_result(C0: list[int], C1: list[int], n_permutations: int) -> bool:
     """Determine whether the sequence is IID by checking that the value of the reference result Tx is between 0.05% and
-    99.95% of the results Ti for the rest of the population of n_sequences sequences.
+    99.95% of the results Ti for the rest of the population of n_permutations sequences.
 
     Parameters
     ----------
@@ -457,7 +457,7 @@ def iid_result(C0: list[int], C1: list[int], n_sequences: int) -> bool:
         counter 0
     C1 : list of int
         counter 1
-    n_sequences : int
+    n_permutations : int
         number of sequences in the population
 
     Returns
@@ -468,7 +468,7 @@ def iid_result(C0: list[int], C1: list[int], n_sequences: int) -> bool:
     if len(C0) != len(C1):
         raise Exception(f"Counter lengths must match: C0 ({len(C0)}), C1 ({len(C1)})")
     for b in range(len(C0)):
-        if (C0[b] + C1[b] <= 0.0005 * n_sequences) or (C0[b] >= 0.9995 * n_sequences):
+        if (C0[b] + C1[b] <= 0.0005 * n_permutations) or (C0[b] >= 0.9995 * n_permutations):
             return False
     return True
 

--- a/utils/config.py
+++ b/utils/config.py
@@ -64,7 +64,7 @@ class Config:
     class StatConfig:
         DEFAULT_SELECTED_TESTS = [i.id for i in permutation_tests.tests]
         DEFAULT_N_SYMBOLS = 1000
-        DEFAULT_N_SEQUENCES = 200
+        DEFAULT_N_PERMUTATIONS = 200
         DEFAULT_N_ITERATIONS = 500
         DEFAULT_P = 2
 
@@ -74,7 +74,7 @@ class Config:
         def _set_defaults(self) -> None:
             """Initialise member variables to default values."""
             self._selected_tests = self.DEFAULT_SELECTED_TESTS
-            self._n_sequences = self.DEFAULT_N_SEQUENCES
+            self._n_permutations = self.DEFAULT_N_PERMUTATIONS
             self._n_symbols = self.DEFAULT_N_SYMBOLS
             self._n_iterations = self.DEFAULT_N_ITERATIONS
             self._p = self.DEFAULT_P
@@ -84,8 +84,8 @@ class Config:
             return self._selected_tests
 
         @property
-        def n_sequences(self):
-            return self._n_sequences
+        def n_permutations(self):
+            return self._n_permutations
 
         @property
         def n_symbols(self):
@@ -268,14 +268,14 @@ class Config:
                         "list of integers",
                     )
 
-            if "n_sequences" in conf["statistical_analysis"]:
-                self.stat._n_sequences = conf["statistical_analysis"]["n_sequences"]
-                if not isinstance(self.stat._n_sequences, int):
+            if "n_permutations" in conf["statistical_analysis"]:
+                self.stat._n_permutations = conf["statistical_analysis"]["n_permutations"]
+                if not isinstance(self.stat._n_permutations, int):
                     logger.error(
                         "%s: %s: invalid configuration parameter %s (expected %s)",
                         filename,
                         "statistical_analysis",
-                        "n_sequences",
+                        "n_permutations",
                         "int",
                     )
 
@@ -350,8 +350,8 @@ class Config:
         # Statistical analysis
         if args.stat_selected_tests:
             self.stat._selected_tests = args.stat_selected_tests
-        if args.stat_n_sequences:
-            self.stat._n_sequences = args.stat_n_sequences
+        if args.stat_n_permutations:
+            self.stat._n_permutations = args.stat_n_permutations
         if args.stat_n_symbols:
             self.stat._n_symbols = args.stat_n_symbols
         if args.stat_n_iterations:
@@ -412,8 +412,8 @@ class Config:
         if (not self.stat._selected_tests) or (not isinstance(self.stat._selected_tests, list)):
             raise ValueError(f'Invalid configuration parameter: "stat_selected_tests" ({self.stat._selected_tests})')
 
-        if (not self.stat._n_sequences) or (not isinstance(self.stat._n_sequences, int)):
-            raise ValueError(f'Invalid configuration parameter: "stat_n_sequences" ({self.stat._n_sequences})')
+        if (not self.stat._n_permutations) or (not isinstance(self.stat._n_permutations, int)):
+            raise ValueError(f'Invalid configuration parameter: "stat_n_permutations" ({self.stat._n_permutations})')
 
         if (not self.stat._n_symbols) or (not isinstance(self.stat._n_symbols, int)):
             raise ValueError(f'Invalid configuration parameter: "stat_n_symbols" ({self.stat._n_symbols})')
@@ -483,12 +483,12 @@ def file_info(conf: Config):
     logger.debug("Input file: %s", conf.input_file)
     logger.debug("Size of file is: %s bytes", size)
     logger.debug("Number of symbols per sequence for counters analysis: %s", conf.stat.n_symbols)
-    logger.debug("Number of sequences wanted for counters analysis: %s", conf.stat.n_sequences)
+    logger.debug("Number of sequences wanted for counters analysis: %s", conf.stat.n_permutations)
     # total number of symbols in the file
     max_symbols = size * 2
     max_sequences = max_symbols / conf.stat.n_symbols
     logger.debug("Maximum sequences that can be generated from the file: %s", max_sequences)
-    tot_seqs = conf.stat._n_iterations * conf.stat.n_sequences
+    tot_seqs = conf.stat._n_iterations * conf.stat.n_permutations
     logger.debug("Total sequences necessary = %s", tot_seqs)
     logger.debug("----------------------------------------------------------------\n")
 
@@ -510,7 +510,7 @@ def config_info(conf: Config):
 
     logger.debug("\nCONFIG INFO - STATISTICAL ANALYSIS")
     logger.debug("Number of symbols per sequence = %s", conf.stat.n_symbols)
-    logger.debug("Number of shuffled sequences = %s", conf.stat.n_sequences)
+    logger.debug("Number of shuffled sequences = %s", conf.stat.n_permutations)
     logger.debug("Number of iterations for counter: %s", conf.stat.n_iterations)
     stat_tests = [permutation_tests.tests[i].name for i in conf.stat.selected_tests]
     logger.debug("Test selected for counter distribution analysis: %s", stat_tests)


### PR DESCRIPTION
Rename n_sequences to n_permutations in statistical analysis part and in ii_results.

Fixes #181 .