### PR TITLE
Rename lag parameter of periodicity

### DIFF
--- a/permutation_tests.py
+++ b/permutation_tests.py
@@ -289,14 +289,14 @@ def _max_collision(S):
     return max(C) + 1
 
 
-def _periodicity(S, y):
+def _periodicity(S, p):
     """Determines the number of periodic samples in the sequence.
 
     Parameters
     ----------
     S : list of int
         sequence of sample values
-    y : int
+    p : int
         lag parameter
 
     Returns
@@ -305,8 +305,8 @@ def _periodicity(S, y):
         number of instances where an element in the sequence is equal to another element that is y positions ahead
     """
     T = 0
-    for i in range(0, len(S) - y):
-        if S[i] == S[i + y]:
+    for i in range(0, len(S) - p):
+        if S[i] == S[i + p]:
             T += 1
     return T
 


### PR DESCRIPTION
Rename lag parameter of periodicity in permutation_tests from y to p to make it consistent with NIST documentation and the rest of the code.

Fixes #193.