### PR TITLE
Fix docstring of histogram_TxTi

### DIFF
--- a/utils/plot.py
+++ b/utils/plot.py
@@ -14,7 +14,7 @@ def histogram_TxTi(Tx, Ti, test_label, plot_dir_h):
 
     Parameters
     ----------
-    Tx : list of float
+    Tx : float
         Tx test values calculated on one sequence
     Ti : list of float
         Ti test values calculated on the shuffled sequences


### PR DESCRIPTION
The type of Tx in the docstring is changed from list of float to float, as is correct.
Fixes #195 and ddresses point 2 of PR #191.