### PR TITLE
Fix header in function save_entropy

### DIFF
--- a/iid_validation/save.py
+++ b/iid_validation/save.py
@@ -115,7 +115,8 @@ def save_entropy(
     header = [
         "file",
         "symbols_occurrences",
-        "n_symbols" "H_min_symbol",
+        "n_symbols",
+        "H_min_symbol",
         "H_min_symbol_sigma",
         "H_min_NIST_symbol",
         "date",


### PR DESCRIPTION
The function save_entropy was missing a comma in the definition of the header for file min_entropy_values.csv